### PR TITLE
Add a monitor for load balancer

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,6 +23,9 @@ Monitor for too many logs with a specific log level in a service's Datadog logs.
 link:./modules/ecs_memory_and_cpu/[Datadog Memory and CPU]::
 Monitor for high CPU and memory usage for a service.
 
+link:./modules/load_balancer/[Datadog Load Balancer]::
+Monitor for unhealthy host count in Elastic Loadbalancer.
+
 == Relevant Repositories
 
 You can use these repos together with this repo!

--- a/modules/load_balancer/README.adoc
+++ b/modules/load_balancer/README.adoc
@@ -16,20 +16,22 @@ IMPORTANT: Remember to add Datadog as a integration in your Slack channel! You a
 Example with default variables.
 [source, hcl]
 ----
-// Make sure to set the `application`-tag on all AWS resources in the provider.
-provider "aws" {
-  default_tags {
-    tags = {
-      application = "infrademo-demo-app"
-    }
-  }
+// Prerequisites:
+module "metadata" {
+  source = "github.com/nsbno/terraform-aws-account-metadata?ref=x.y.z"
+}
+
+module "service" {
+  source = "github.com/nsbno/terraform-aws-ecs-service?ref=x.y.z"
+  [...]
 }
 
 module "datadog_load_balancer" {
   source = "github.com/nsbno/terraform-datadog-monitors//modules/load_balancer?ref=x.y.z"
 
-  application_tag_value = "infrademo-demo-app"
-  service_display_name  = "Infrademo Demo App"
+  service_display_name     = "Infrademo Demo App"
+  target_group_arn_suffix  = module.service.target_group_arn_suffixes[0]
+  load_balancer_arn_suffix = module.metadata.load_balancer.arn_suffix
 
   # channel name only, e.g. tmp-test-slack
   slack_channel_to_notify = "tmp-test-slack"
@@ -39,20 +41,22 @@ module "datadog_load_balancer" {
 Example where you can configure variables.
 [source, hcl]
 ----
-// Make sure to set the `application`-tag on all AWS resources in the provider.
-provider "aws" {
-  default_tags {
-    tags = {
-      application = "infrademo-demo-app"
-    }
-  }
+// Prerequisites:
+module "metadata" {
+  source = "github.com/nsbno/terraform-aws-account-metadata?ref=x.y.z"
+}
+
+module "service" {
+  source = "github.com/nsbno/terraform-aws-ecs-service?ref=x.y.z"
+  [...]
 }
 
 module "datadog_load_balancer" {
   source = "github.com/nsbno/terraform-datadog-monitors//modules/load_balancer?ref=x.y.z"
 
-  application_tag_value = "infrademo-demo-app"
-  service_display_name  = "Infrademo Demo App"
+  service_display_name     = "Infrademo Demo App"
+  target_group_arn_suffix  = module.service.target_group_arn_suffixes[0]
+  load_balancer_arn_suffix = module.metadata.load_balancer.arn_suffix
 
   threshold    = 2
   period       = "10m"

--- a/modules/load_balancer/README.adoc
+++ b/modules/load_balancer/README.adoc
@@ -1,0 +1,61 @@
+= Load Balancer Monitor
+:!toc-title:
+:!toc-placement:
+:toc:
+
+Monitor for unhealthy host count in Elastic Loadbalancer.
+
+toc::[]
+
+== Usage
+
+Remember to check out the link:variables.tf[*variables*] to see all options.
+
+IMPORTANT: Remember to add Datadog as a integration in your Slack channel! You also need to integrate Datadog with your AWS account.
+
+Example with default variables.
+[source, hcl]
+----
+module "datadog_load_balancer" {
+  source = "github.com/nsbno/terraform-datadog-monitors//modules/load_balancer?ref=x.y.z"
+
+  service_name         = module.datadog_service.service_name
+  service_display_name = "Infrademo Demo App"
+
+  # channel name only, e.g. tmp-test-slack
+  slack_channel_to_notify = "tmp-test-slack"
+}
+----
+
+Example where you can configure variables.
+[source, hcl]
+----
+module "datadog_load_balancer" {
+  source = "github.com/nsbno/terraform-datadog-monitors//modules/load_balancer?ref=x.y.z"
+
+  service_name         = module.datadog_service.service_name
+  service_display_name = "Infrademo Demo App"
+
+  threshold    = 2
+  period       = "10m"
+
+  # If you want to use your team's own workflow
+  workflow_to_attach = "@workflow-notify-slack-of-monitor-event"
+}
+----
+
+== Relevant Repositories
+
+You can use these repos together with this repo!
+
+link:https://github.com/nsbno/terraform-datadog-service[`nsbno/terraform-datadog-service`]::
+Connect a DataDog service to a team with metadata.
+
+link:https://github.com/nsbno/terraform-aws-ecs-service[`nsbno/terraform-aws-ecs-service`]::
+Connect an AWS ECS service to Datadog.
+
+link:https://github.com/nsbno/terraform-aws-lambda[`nsbno/terraform-aws-lambda`]::
+Connect an AWS Lambda function to Datadog.
+
+link:github.com/nsbno/terraform-datadog-aws-integration[`nsbno/terraform-datadog-aws-integration`]::
+Connect an AWS account to Datadog.

--- a/modules/load_balancer/README.adoc
+++ b/modules/load_balancer/README.adoc
@@ -16,11 +16,20 @@ IMPORTANT: Remember to add Datadog as a integration in your Slack channel! You a
 Example with default variables.
 [source, hcl]
 ----
+// Make sure to set the `application`-tag on all AWS resources in the provider.
+provider "aws" {
+  default_tags {
+    tags = {
+      application = "infrademo-demo-app"
+    }
+  }
+}
+
 module "datadog_load_balancer" {
   source = "github.com/nsbno/terraform-datadog-monitors//modules/load_balancer?ref=x.y.z"
 
-  service_name         = module.datadog_service.service_name
-  service_display_name = "Infrademo Demo App"
+  application_tag_value = "infrademo-demo-app"
+  service_display_name  = "Infrademo Demo App"
 
   # channel name only, e.g. tmp-test-slack
   slack_channel_to_notify = "tmp-test-slack"
@@ -30,11 +39,20 @@ module "datadog_load_balancer" {
 Example where you can configure variables.
 [source, hcl]
 ----
+// Make sure to set the `application`-tag on all AWS resources in the provider.
+provider "aws" {
+  default_tags {
+    tags = {
+      application = "infrademo-demo-app"
+    }
+  }
+}
+
 module "datadog_load_balancer" {
   source = "github.com/nsbno/terraform-datadog-monitors//modules/load_balancer?ref=x.y.z"
 
-  service_name         = module.datadog_service.service_name
-  service_display_name = "Infrademo Demo App"
+  application_tag_value = "infrademo-demo-app"
+  service_display_name  = "Infrademo Demo App"
 
   threshold    = 2
   period       = "10m"

--- a/modules/load_balancer/main.tf
+++ b/modules/load_balancer/main.tf
@@ -1,8 +1,7 @@
 locals {
-  service_tag      = var.service_name != null ? format("service:%s", var.service_name) : null
-  service_name_tag = var.service_name != null ? format("servicename:%s", var.service_name) : null
+  service_tag      = var.application_tag_value != null ? format("service:%s", var.application_tag_value) : null
 
-  display_name = var.service_display_name != null ? var.service_display_name : title(var.service_name)
+  display_name = var.service_display_name != null ? var.service_display_name : title(var.application_tag_value)
 
   # The account alias includes the name of the environment we are in as a suffix
   split_alias       = split("-", data.aws_iam_account_alias.this.account_alias)
@@ -11,7 +10,7 @@ locals {
   env_tag           = "env:${local.environment}"
   account_name_tag  = "account-name:${data.aws_iam_account_alias.this.account_alias}"
   team_tag          = "team:${data.aws_ssm_parameter.team_name.value}"
-  application_tag   = "application:${var.service_name}"
+  application_tag   = "application:${var.application_tag_value}"
 }
 
 data "aws_iam_account_alias" "this" {}

--- a/modules/load_balancer/main.tf
+++ b/modules/load_balancer/main.tf
@@ -1,0 +1,54 @@
+locals {
+  service_tag      = var.service_name != null ? format("service:%s", var.service_name) : null
+  service_name_tag = var.service_name != null ? format("servicename:%s", var.service_name) : null
+
+  display_name = var.service_display_name != null ? var.service_display_name : title(var.service_name)
+
+  # The account alias includes the name of the environment we are in as a suffix
+  split_alias       = split("-", data.aws_iam_account_alias.this.account_alias)
+  environment_index = length(local.split_alias) - 1
+  environment       = local.split_alias[local.environment_index]
+  env_tag           = "env:${local.environment}"
+  account_name_tag  = "account-name:${data.aws_iam_account_alias.this.account_alias}"
+  team_tag          = "team:${data.aws_ssm_parameter.team_name.value}"
+}
+
+data "aws_iam_account_alias" "this" {}
+
+data "aws_ssm_parameter" "team_name" {
+  name = "/__platform__/team_name_handle"
+}
+
+resource "datadog_monitor" "unhealthy_host_count" {
+  name = "${local.display_name}: Unhealthy host count"
+  type = "query alert"
+  tags = compact([local.account_name_tag, local.service_tag, local.env_tag, local.team_tag])
+
+  priority         = var.priority
+  evaluation_delay = var.evaluation_delay
+  on_missing_data  = var.on_missing_data
+
+  include_tags             = false
+  notification_preset_name = "hide_all"
+  require_full_window      = true
+
+  query   = "min(last_${var.period}):min:aws.applicationelb.healthy_host_count.minimum{application:${var.service_name} < ${var.threshold}"
+  message = var.workflow_to_attach != null ? var.workflow_to_attach : <<EOT
+  @slack-${var.slack_channel_to_notify}
+
+  {{#is_alert}}
+    ${local.display_name}: Unhealthy host count of {{value}}. 
+  {{/is_alert}}
+
+  {{#is_recovery}}
+    ${local.display_name} is back to a healthy host count of {{value}}.
+  {{/is_recovery}}
+  EOT
+
+  lifecycle {
+    precondition {
+      condition     = (var.workflow_to_attach != null) != (var.slack_channel_to_notify != null)
+      error_message = "Exactly one of workflow_to_attach or slack_channel_to_notify must be provided, not both."
+    }
+  }
+}

--- a/modules/load_balancer/variables.tf
+++ b/modules/load_balancer/variables.tf
@@ -1,5 +1,5 @@
-variable "service_name" {
-  description = "The name of the service."
+variable "application_tag_value" {
+  description = "The value of the `application`-tag of the resource to monitor."
   type        = string
 }
 

--- a/modules/load_balancer/variables.tf
+++ b/modules/load_balancer/variables.tf
@@ -1,0 +1,69 @@
+variable "service_name" {
+  description = "The name of the service."
+  type        = string
+}
+
+variable "service_display_name" {
+  description = "The display name of the service"
+  type        = string
+
+  default = null
+}
+
+variable "workflow_to_attach" {
+  # https://app.datadoghq.eu/workflow
+  description = "The workflow to attach to the monitor. Find your workflow handle in the Datadog page for workflows"
+  type        = string
+
+  default = null
+}
+
+variable "slack_channel_to_notify" {
+  description = "Slack channel name"
+  type        = string
+
+  default     = null
+}
+
+/*
+ * == Alarm Configuration
+ */
+variable "threshold" {
+  description = "Expected amount of healthy hosts. Anything lower than this will trigger an alert"
+  type        = number
+
+  default = 1
+}
+
+variable "period" {
+  # see https://docs.datadoghq.com/monitors/configuration/?tab=thresholdalert#rolling-time-windows for more information
+  description = "The time window to check for host count"
+  type        = string
+
+  default = "5m"
+}
+
+variable "priority" {
+  description = "The priority of the monitor. Can be one of: 1, 2, 3, 4"
+  type        = number
+
+  default = 2
+}
+
+variable "evaluation_delay" {
+  default     = 900
+  type        = number
+  description = "Delay before evaluating the monitor. Datadog suggests 900 seconds for AWS metrics"
+}
+
+variable "require_full_window" {
+  default     = false
+  type        = bool
+  description = "A boolean indicating whether this monitor needs a full window of data before it’s evaluated. Datadog recommends you set this to False for sparse metrics, otherwise some evaluations are skipped. Default: False"
+}
+
+variable "on_missing_data" {
+  default = "default"
+  type = string
+  description = "How to treat missing data"
+}

--- a/modules/load_balancer/variables.tf
+++ b/modules/load_balancer/variables.tf
@@ -1,5 +1,15 @@
-variable "application_tag_value" {
-  description = "The value of the `application`-tag of the resource to monitor."
+variable "service_name" {
+  description = "The name of the service. A group of function names can be part of the same service"
+  type        = string
+}
+
+variable "target_group_arn_suffix" {
+  description = "Target Group to monitor"
+  type        = string
+}
+
+variable "load_balancer_arn_suffix" {
+  description = "Load Balancer to monitor"
   type        = string
 }
 

--- a/modules/load_balancer/variables.tf
+++ b/modules/load_balancer/variables.tf
@@ -22,7 +22,7 @@ variable "slack_channel_to_notify" {
   description = "Slack channel name"
   type        = string
 
-  default     = null
+  default = null
 }
 
 /*
@@ -63,7 +63,18 @@ variable "require_full_window" {
 }
 
 variable "on_missing_data" {
-  default = "default"
-  type = string
+  default     = "default"
+  type        = string
   description = "How to treat missing data"
+}
+
+variable "include_tags" {
+  default     = false
+  description = "Whether notifications from this monitor automatically insert its triggering tags into the title"
+}
+
+variable "notification_preset_name" {
+  default     = "hide_all"
+  type        = string
+  description = "The notification preset to use for this monitor. See https://docs.datadoghq.com/monitors/notifications/?tab=notificationpresets#notification-presets"
 }

--- a/modules/load_balancer/versions.tf
+++ b/modules/load_balancer/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0.0"
+    }
+    datadog = {
+      source  = "DataDog/datadog"
+      version = ">= 3.55.0"
+    }
+  }
+}


### PR DESCRIPTION
Speiler eksisterende Cloudwatch-alarm for antall friske hosts sett fra lastbalanserer.

Trigger alarm på minimum-måling under terskel. Friskmeldes etter 5 minutter med OK antall hosts.