### PR TITLE
Update monitors

### DIFF
--- a/modules/api_gateway/main.tf
+++ b/modules/api_gateway/main.tf
@@ -9,25 +9,26 @@ locals {
   environment       = local.split_alias[local.environment_index]
   env_tag           = "env:${local.environment}"
 
-  latency_monitor_message = <<EOT
+  latency_monitor_message = <<-EOT
   @slack-${var.slack_channel_to_notify}
-    {{#is_alert}}
-    API: ${var.api_name}
-    Threshold: ${var.latency_alert_threshold} ms
-    Current value: {{value}} ms
-    {{/is_alert}}
 
-    {{#is_recovery}}
-    Latency is ok again.
-    {{/is_recovery}}
+  {{#is_alert}}
+  API: ${var.api_name}
+  Threshold: ${var.latency_alert_threshold} ms
+  Current value: {{value}} ms
+  {{/is_alert}}
+
+  {{#is_recovery}}
+  Latency is ok again.
+  {{/is_recovery}}
   EOT
 
-  error_5xx_message = <<EOT
+  error_5xx_message = <<-EOT
   @slack-${var.slack_channel_to_notify}
 
-    {{#is_alert}}
-    {{value}} 5xx errors last ${var.error_5xx_period}}
-    {{/is_alert}}
+  {{#is_alert}}
+  {{value}} 5xx errors last ${var.error_5xx_period}}
+  {{/is_alert}}
   EOT
 }
 

--- a/modules/api_gateway/main.tf
+++ b/modules/api_gateway/main.tf
@@ -27,7 +27,7 @@ locals {
   @slack-${var.slack_channel_to_notify}
 
   {{#is_alert}}
-  {{value}} 5xx errors last ${var.error_5xx_period}}
+  {{value}} 5xx errors last ${var.error_5xx_period}
   {{/is_alert}}
   EOT
 }

--- a/modules/api_gateway/main.tf
+++ b/modules/api_gateway/main.tf
@@ -76,7 +76,7 @@ resource "datadog_monitor" "monitor_5xx" {
   include_tags             = var.include_tags
   notification_preset_name = var.notification_preset_name
 
-  query   = "sum(last_${var.latency_evaluation_period}):avg:aws.apigateway.5xxerror{${local.env_tag}, apiname:${var.api_name}}.as_count() >= ${var.error_5xx_threshold}"
+  query   = "sum(last_${var.latency_evaluation_period}):sum:aws.apigateway.5xxerror{${local.env_tag}, apiname:${var.api_name}}.as_count() >= ${var.error_5xx_threshold}"
   message = local.error_5xx_message
 
   lifecycle {

--- a/modules/ecs_memory_and_cpu/main.tf
+++ b/modules/ecs_memory_and_cpu/main.tf
@@ -36,7 +36,7 @@ resource "datadog_monitor" "high_memory_usage" {
 @slack-${var.slack_channel_to_notify}
 
 {{#is_alert}}
-  ${local.display_name} has crossed the memory usage threshold of {{threshold}}%. Average last 5 minutes was {{value}}%
+  ${local.display_name} has crossed the memory usage threshold of {{threshold}}%. Average last ${var.memory_period} was {{value}}%
 {{/is_alert}}
 
 {{#is_recovery}}
@@ -69,7 +69,7 @@ resource "datadog_monitor" "high_cpu_usage" {
 @slack-${var.slack_channel_to_notify}
 
 {{#is_alert}}
-  ${local.display_name} has crossed the CPU usage threshold of {{threshold}}%. Average last 5 minutes was {{value}}%
+  ${local.display_name} has crossed the CPU usage threshold of {{threshold}}%. Average last ${var.cpu_period} was {{value}}%
 {{/is_alert}}
 
 {{#is_recovery}}

--- a/modules/load_balancer/README.adoc
+++ b/modules/load_balancer/README.adoc
@@ -29,7 +29,7 @@ module "service" {
 module "datadog_load_balancer" {
   source = "github.com/nsbno/terraform-datadog-monitors//modules/load_balancer?ref=x.y.z"
 
-  service_display_name     = "Infrademo Demo App"
+  service_name             = module.service.service_name
   target_group_arn_suffix  = module.service.target_group_arn_suffixes[0]
   load_balancer_arn_suffix = module.metadata.load_balancer.arn_suffix
 
@@ -54,6 +54,7 @@ module "service" {
 module "datadog_load_balancer" {
   source = "github.com/nsbno/terraform-datadog-monitors//modules/load_balancer?ref=x.y.z"
 
+  service_name             = module.service.service_name
   service_display_name     = "Infrademo Demo App"
   target_group_arn_suffix  = module.service.target_group_arn_suffixes[0]
   load_balancer_arn_suffix = module.metadata.load_balancer.arn_suffix

--- a/modules/load_balancer/main.tf
+++ b/modules/load_balancer/main.tf
@@ -33,8 +33,8 @@ resource "datadog_monitor" "unhealthy_host_count" {
   notification_preset_name = var.notification_preset_name
   require_full_window      = var.require_full_window
 
-  query   = "min(last_${var.period}):min:aws.applicationelb.healthy_host_count{${local.target_group_tag}, ${local.load_balancer_tag}} < ${var.threshold}"
-  message = var.workflow_to_attach != null ? var.workflow_to_attach : <<EOT
+  query   = "min(last_${var.period}):sum:aws.applicationelb.healthy_host_count{${local.target_group_tag}, ${local.load_balancer_tag}} < ${var.threshold}"
+  message = var.workflow_to_attach != null ? var.workflow_to_attach : <<-EOT
   @slack-${var.slack_channel_to_notify}
 
   {{#is_alert}}

--- a/modules/log_level/main.tf
+++ b/modules/log_level/main.tf
@@ -26,7 +26,7 @@ resource "datadog_monitor" "too_many_logs_of_log_level" {
   priority = var.priority
 
   query   = "logs(\"${local.log_query}\").index(\"${var.index_to_monitor}\").rollup(\"count\").last(\"${var.period}\") > ${var.alert_threshold}"
-  message = var.workflow_to_attach != null ? var.workflow_to_attach : "@slack-${var.slack_channel_to_notify})"
+  message = var.workflow_to_attach != null ? var.workflow_to_attach : "@slack-${var.slack_channel_to_notify}"
 
   enable_logs_sample       = true
   require_full_window      = false

--- a/modules/log_level/main.tf
+++ b/modules/log_level/main.tf
@@ -28,8 +28,9 @@ resource "datadog_monitor" "too_many_logs_of_log_level" {
   query   = "logs(\"${local.log_query}\").index(\"${var.index_to_monitor}\").rollup(\"count\").last(\"${var.period}\") > ${var.alert_threshold}"
   message = var.workflow_to_attach != null ? var.workflow_to_attach : "@slack-${var.slack_channel_to_notify})"
 
-  enable_logs_sample  = true
-  require_full_window = false
+  enable_logs_sample       = true
+  require_full_window      = false
+  notification_preset_name = var.notification_preset_name
 
   lifecycle {
     precondition {

--- a/modules/log_level/variables.tf
+++ b/modules/log_level/variables.tf
@@ -61,3 +61,9 @@ variable "index_to_monitor" {
 
   default = "main"
 }
+
+variable "notification_preset_name" {
+  default     = "hide_handles"
+  type        = string
+  description = "The notification preset to use for this monitor. See https://docs.datadoghq.com/monitors/notifications/?tab=notificationpresets#notification-presets"
+}


### PR DESCRIPTION
Make some updates and bug fixes to the monitors.

The healthy host count evaluated to 1 for a service with 2 instances because the metric counts per AZ --> use sum to count hosts in all the AZ's

The 5xx errors monitor did not show the count of errors --> use sum instead of avg