### PR TITLE
Handle a list of target groups

### DIFF
--- a/modules/load_balancer/README.adoc
+++ b/modules/load_balancer/README.adoc
@@ -54,10 +54,10 @@ module "service" {
 module "datadog_load_balancer" {
   source = "github.com/nsbno/terraform-datadog-monitors//modules/load_balancer?ref=x.y.z"
 
-  service_name             = module.service.service_name
-  service_display_name     = "Infrademo Demo App"
-  target_group_arn_suffix  = module.service.target_group_arn_suffixes[0]
-  load_balancer_arn_suffix = module.metadata.load_balancer.arn_suffix
+  service_name              = module.service.service_name
+  service_display_name      = "Infrademo Demo App"
+  target_group_arn_suffixes = concat(values(module.service.target_group_arn_suffixes), values(module.service.secondary_target_group_arn_suffixes))
+  load_balancer_arn_suffix  = module.metadata.load_balancer.arn_suffix
 
   threshold    = 2
   period       = "10m"

--- a/modules/load_balancer/README.adoc
+++ b/modules/load_balancer/README.adoc
@@ -29,9 +29,9 @@ module "service" {
 module "datadog_load_balancer" {
   source = "github.com/nsbno/terraform-datadog-monitors//modules/load_balancer?ref=x.y.z"
 
-  service_name             = module.service.service_name
-  target_group_arn_suffix  = module.service.target_group_arn_suffixes[0]
-  load_balancer_arn_suffix = module.metadata.load_balancer.arn_suffix
+  service_name               = module.service.service_name
+  target_group_arn_suffixes  = values(module.service.target_group_arn_suffixes)
+  load_balancer_arn_suffix   = module.metadata.load_balancer.arn_suffix
 
   # channel name only, e.g. tmp-test-slack
   slack_channel_to_notify = "tmp-test-slack"

--- a/modules/load_balancer/variables.tf
+++ b/modules/load_balancer/variables.tf
@@ -3,9 +3,9 @@ variable "service_name" {
   type        = string
 }
 
-variable "target_group_arn_suffix" {
-  description = "Target Group to monitor"
-  type        = string
+variable "target_group_arn_suffixes" {
+  description = "Target groups to monitor"
+  type        = list(string)
 }
 
 variable "load_balancer_arn_suffix" {


### PR DESCRIPTION
Blue/green deployment alters between two target groups, therefore we must check both groups in the monitor

Will create a query in this style
```
 query  = "min(last_5m):sum:aws.applicationelb.healthy_host_count{(targetgroup:targetgroup/tf-123/678 OR targetgroup:targetgroup/secondary-8080/456) AND loadbalancer:app/applications-alb/123} < 1"
```